### PR TITLE
[codex] Implement phase 2 post-merge refinement

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2,9 +2,11 @@ import json
 from typing import Any
 
 from pydantic import field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
     API_PORT: int = 8000
     DATABASE_URL: str = "sqlite+aiosqlite:///./bauclock.db"
     BOT_TOKEN: str = ""
@@ -43,10 +45,5 @@ class Settings(BaseSettings):
         if isinstance(value, tuple):
             value = list(value)
         return [str(item).strip().lstrip("@").casefold() for item in value if str(item).strip()]
-    
-    # We load this locally if not provided in env for local tests
-    class Config:
-        env_file = ".env"
-        extra = "ignore"
-        
+
 settings = Settings()

--- a/api/routers/compliance.py
+++ b/api/routers/compliance.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from access.legacy_policy import dashboard_access_role
 from api.redis_client import redis_client
 from api.services.arbzg_reporting import build_company_arbzg_day_report
+from api.services.arbzg_reviews import (
+    list_arbzg_findings,
+    open_arbzg_finding,
+    serialize_arbzg_finding,
+    set_arbzg_finding_state,
+)
 from api.services.dashboard_access import DashboardAccessError, get_dashboard_worker
 from api.services.legal_acceptance import get_legal_acceptance_overview
 from api.services.retention import run_retention_cycle
@@ -20,8 +27,24 @@ from db.security import decrypt_string
 router = APIRouter()
 
 
+class ArbzgFindingOpenRequest(BaseModel):
+    worker_id: int
+    target_date: date
+    finding_code: str
+    severity: str = "warning"
+
+
+class ArbzgFindingStateUpdateRequest(BaseModel):
+    state: str
+    reason: str | None = None
+
+
 def _compliance_access_denied() -> HTTPException:
     return HTTPException(status_code=403, detail="Forbidden")
+
+
+def _compliance_bad_request(detail: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=detail)
 
 
 def _require_compliance_company_scope(actor_worker: Worker, company_id: int | None) -> int:
@@ -89,6 +112,8 @@ async def compliance_legal_overview(
         "company_documents_complete": overview["company_documents_complete"],
         "company_documents": overview["company_document_states"],
         "worker_notice_completion": overview["worker_notice_completion"],
+        "gps_site_presence_requirement_counts": overview["gps_site_presence_requirement_counts"],
+        "worker_notice_states": overview["worker_notice_states"],
         "incomplete_workers": incomplete_workers,
     }
 
@@ -109,6 +134,7 @@ async def compliance_retention_report(
         db,
         company_id=scoped_company_id,
         destructive=False,
+        redis_client=redis_client,
     )
 
 
@@ -130,3 +156,93 @@ async def compliance_arbzg_report(
         company_id=scoped_company_id,
         target_day=target_day,
     )
+
+
+@router.get("/compliance/arbzg-findings")
+async def compliance_arbzg_findings(
+    token: str | None = Query(default=None),
+    company_id: int | None = Query(default=None),
+    target_day: date | None = Query(default=None),
+    state: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        actor_worker = await get_dashboard_worker(token, db, redis_client)
+        scoped_company_id = _require_compliance_company_scope(actor_worker, company_id)
+    except DashboardAccessError as exc:
+        raise _compliance_access_denied() from exc
+
+    try:
+        return {
+            "company_id": scoped_company_id,
+            "items": await list_arbzg_findings(
+                db,
+                company_id=scoped_company_id,
+                target_date=target_day,
+                state=state,
+            ),
+        }
+    except ValueError as exc:
+        raise _compliance_bad_request(str(exc)) from exc
+
+
+@router.post("/compliance/arbzg-findings/open")
+async def compliance_open_arbzg_review_finding(
+    payload: ArbzgFindingOpenRequest,
+    token: str | None = Query(default=None),
+    company_id: int | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        actor_worker = await get_dashboard_worker(token, db, redis_client)
+        scoped_company_id = _require_compliance_company_scope(actor_worker, company_id)
+    except DashboardAccessError as exc:
+        raise _compliance_access_denied() from exc
+
+    try:
+        finding = await open_arbzg_finding(
+            db,
+            company_id=scoped_company_id,
+            worker_id=payload.worker_id,
+            target_date=payload.target_date,
+            finding_code=payload.finding_code,
+            severity=payload.severity,
+            actor_worker_id=actor_worker.id,
+        )
+    except ValueError as exc:
+        raise _compliance_bad_request(str(exc)) from exc
+
+    await db.commit()
+    await db.refresh(finding)
+    return serialize_arbzg_finding(finding)
+
+
+@router.post("/compliance/arbzg-findings/{finding_id}/state")
+async def compliance_update_arbzg_review_finding(
+    finding_id: int,
+    payload: ArbzgFindingStateUpdateRequest,
+    token: str | None = Query(default=None),
+    company_id: int | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        actor_worker = await get_dashboard_worker(token, db, redis_client)
+        scoped_company_id = _require_compliance_company_scope(actor_worker, company_id)
+    except DashboardAccessError as exc:
+        raise _compliance_access_denied() from exc
+
+    try:
+        finding = await set_arbzg_finding_state(
+            db,
+            finding_id=finding_id,
+            company_id=scoped_company_id,
+            state=payload.state,
+            reason=payload.reason,
+            actor_worker_id=actor_worker.id,
+        )
+    except ValueError as exc:
+        raise _compliance_bad_request(str(exc)) from exc
+
+    await db.commit()
+    await db.refresh(finding)
+    return serialize_arbzg_finding(finding)

--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -7,6 +7,7 @@ from access.legacy_policy import can_view_admin_features
 from api.bot_client import send_telegram_message, send_telegram_document
 from api.logger import logger
 from api.config import settings
+from api.redis_client import redis_client
 from api.services.arbzg_policy import get_worker_arbzg_flags
 from api.services.retention import run_retention_cycle
 from db.database import SessionLocal as async_session_maker
@@ -66,7 +67,7 @@ async def check_arbzg_pauses():
 async def run_retention_foundation():
     logger.info("Executing retention foundation run...")
     async with async_session_maker() as session:
-        report = await run_retention_cycle(session)
+        report = await run_retention_cycle(session, redis_client=redis_client)
         logger.info(f"Retention report: {report}")
 
 async def warn_unclosed_days_1800():

--- a/api/services/arbzg_reporting.py
+++ b/api/services/arbzg_reporting.py
@@ -8,7 +8,22 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.services.arbzg_policy import evaluate_arbzg_flags
+from api.services.arbzg_reviews import load_arbzg_finding_map
 from db.models import EventType, TimeEvent, Worker
+
+
+def _review_summary_state(states: list[str]) -> tuple[str, bool]:
+    if not states:
+        return "clean", False
+    unique_states = set(states)
+    if unique_states == {"open"}:
+        return "open", False
+    if "open" in unique_states:
+        return "open", False
+    if len(unique_states) == 1:
+        state = next(iter(unique_states))
+        return state, True
+    return "mixed", True
 
 
 async def build_company_arbzg_day_report(
@@ -40,6 +55,7 @@ async def build_company_arbzg_day_report(
             "company_id": company_id,
             "date": target_day.isoformat(),
             "summary_counts": {},
+            "review_state_counts": {},
             "total_workers": 0,
             "flagged_workers": 0,
             "items": [],
@@ -75,23 +91,46 @@ async def build_company_arbzg_day_report(
         for worker_id, previous_checkout_at in previous_checkout_rows
     }
 
+    finding_map = await load_arbzg_finding_map(
+        db,
+        company_id=company_id,
+        target_date=target_day,
+        worker_ids=worker_ids,
+    )
     summary_counts: Counter[str] = Counter()
+    review_state_counts: Counter[str] = Counter()
     items: list[dict[str, Any]] = []
     for worker in workers:
-        flags = evaluate_arbzg_flags(
+        raw_flags = evaluate_arbzg_flags(
             events_by_worker.get(int(worker.id), []),
             now=effective_now,
             previous_checkout_at=previous_checkout_by_worker.get(int(worker.id)),
         )
-        for flag in flags:
+        serialized_flags: list[dict[str, Any]] = []
+        for flag in raw_flags:
+            finding = finding_map.get((int(worker.id), str(flag["code"])))
+            review_state = str(finding["state"]) if finding is not None else "open"
+            serialized_flags.append(
+                {
+                    **flag,
+                    "finding_id": finding["id"] if finding is not None else None,
+                    "review_state": review_state,
+                    "review_reason": finding["state_reason"] if finding is not None else None,
+                }
+            )
             summary_counts.update([str(flag["code"])])
+
+        item_review_state, is_reviewed = _review_summary_state(
+            [str(flag["review_state"]) for flag in serialized_flags]
+        )
+        review_state_counts.update([item_review_state])
         items.append(
             {
                 "worker_id": int(worker.id),
                 "date": target_day.isoformat(),
-                "flags": flags,
-                "review_state": "unreviewed" if flags else "clean",
-                "is_reviewed": False,
+                "flags": serialized_flags,
+                "review_state": item_review_state,
+                "is_reviewed": is_reviewed,
             }
         )
 
@@ -99,6 +138,7 @@ async def build_company_arbzg_day_report(
         "company_id": company_id,
         "date": target_day.isoformat(),
         "summary_counts": dict(summary_counts),
+        "review_state_counts": dict(review_state_counts),
         "total_workers": len(workers),
         "flagged_workers": sum(1 for item in items if item["flags"]),
         "items": items,

--- a/api/services/arbzg_reviews.py
+++ b/api/services/arbzg_reviews.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import ArbzgFinding, ArbzgFindingState, Worker
+
+
+VALID_ARBZG_FINDING_STATES = {
+    ArbzgFindingState.OPEN.value,
+    ArbzgFindingState.REVIEWED.value,
+    ArbzgFindingState.RESOLVED.value,
+    ArbzgFindingState.DISMISSED.value,
+}
+
+
+def _normalize_state(state: str) -> str:
+    normalized = (state or "").strip().casefold()
+    if normalized not in VALID_ARBZG_FINDING_STATES:
+        raise ValueError("invalid_arbzg_finding_state")
+    return normalized
+
+
+def _normalize_text(value: str | None) -> str | None:
+    normalized = (value or "").strip()
+    return normalized or None
+
+
+def serialize_arbzg_finding(finding: ArbzgFinding) -> dict[str, object]:
+    return {
+        "id": int(finding.id),
+        "company_id": int(finding.company_id),
+        "worker_id": int(finding.worker_id),
+        "target_date": finding.target_date.isoformat(),
+        "finding_code": str(finding.finding_code),
+        "severity": str(finding.severity),
+        "state": str(finding.state),
+        "state_reason": finding.state_reason,
+        "created_by_worker_id": finding.created_by_worker_id,
+        "updated_by_worker_id": finding.updated_by_worker_id,
+        "created_at": finding.created_at.isoformat() if finding.created_at else None,
+        "updated_at": finding.updated_at.isoformat() if finding.updated_at else None,
+    }
+
+
+async def _require_worker_company_scope(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    worker_id: int,
+) -> None:
+    worker = await db.get(Worker, worker_id)
+    if worker is None or int(worker.company_id) != int(company_id):
+        raise ValueError("arbzg_worker_company_scope_denied")
+
+
+async def open_arbzg_finding(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    worker_id: int,
+    target_date: date,
+    finding_code: str,
+    severity: str,
+    actor_worker_id: int | None = None,
+) -> ArbzgFinding:
+    await _require_worker_company_scope(db, company_id=company_id, worker_id=worker_id)
+    normalized_code = (finding_code or "").strip()
+    normalized_severity = (severity or "").strip() or "warning"
+    if not normalized_code:
+        raise ValueError("finding_code_required")
+
+    finding = await db.scalar(
+        select(ArbzgFinding).where(
+            ArbzgFinding.company_id == company_id,
+            ArbzgFinding.worker_id == worker_id,
+            ArbzgFinding.target_date == target_date,
+            ArbzgFinding.finding_code == normalized_code,
+        )
+    )
+
+    if finding is None:
+        finding = ArbzgFinding(
+            company_id=company_id,
+            worker_id=worker_id,
+            target_date=target_date,
+            finding_code=normalized_code,
+            severity=normalized_severity,
+            state=ArbzgFindingState.OPEN.value,
+            created_by_worker_id=actor_worker_id,
+            updated_by_worker_id=actor_worker_id,
+        )
+        db.add(finding)
+        await db.flush()
+        return finding
+
+    finding.severity = normalized_severity
+    finding.state = ArbzgFindingState.OPEN.value
+    finding.state_reason = None
+    finding.updated_by_worker_id = actor_worker_id
+    db.add(finding)
+    await db.flush()
+    return finding
+
+
+async def set_arbzg_finding_state(
+    db: AsyncSession,
+    *,
+    finding_id: int,
+    company_id: int,
+    state: str,
+    actor_worker_id: int | None = None,
+    reason: str | None = None,
+) -> ArbzgFinding:
+    finding = await db.get(ArbzgFinding, finding_id)
+    if finding is None:
+        raise ValueError("arbzg_finding_not_found")
+    if int(finding.company_id) != int(company_id):
+        raise ValueError("arbzg_finding_scope_denied")
+
+    finding.state = _normalize_state(state)
+    finding.state_reason = _normalize_text(reason)
+    finding.updated_by_worker_id = actor_worker_id
+    db.add(finding)
+    await db.flush()
+    return finding
+
+
+async def list_arbzg_findings(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    target_date: date | None = None,
+    worker_id: int | None = None,
+    state: str | None = None,
+) -> list[dict[str, object]]:
+    stmt = (
+        select(ArbzgFinding)
+        .where(ArbzgFinding.company_id == company_id)
+        .order_by(
+            ArbzgFinding.target_date.desc(),
+            ArbzgFinding.worker_id.asc(),
+            ArbzgFinding.finding_code.asc(),
+            ArbzgFinding.id.asc(),
+        )
+    )
+    if target_date is not None:
+        stmt = stmt.where(ArbzgFinding.target_date == target_date)
+    if worker_id is not None:
+        stmt = stmt.where(ArbzgFinding.worker_id == worker_id)
+    if state is not None:
+        stmt = stmt.where(ArbzgFinding.state == _normalize_state(state))
+
+    findings = (await db.execute(stmt)).scalars().all()
+    return [serialize_arbzg_finding(finding) for finding in findings]
+
+
+async def load_arbzg_finding_map(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    target_date: date,
+    worker_ids: list[int] | None = None,
+) -> dict[tuple[int, str], dict[str, object]]:
+    stmt = select(ArbzgFinding).where(
+        ArbzgFinding.company_id == company_id,
+        ArbzgFinding.target_date == target_date,
+    )
+    if worker_ids:
+        stmt = stmt.where(ArbzgFinding.worker_id.in_(worker_ids))
+
+    findings = (await db.execute(stmt)).scalars().all()
+    return {
+        (int(finding.worker_id), str(finding.finding_code)): serialize_arbzg_finding(finding)
+        for finding in findings
+    }

--- a/api/services/legal_acceptance.py
+++ b/api/services/legal_acceptance.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.services.legal_acceptance_requirements import (
     GPS_SITE_PRESENCE_NOTICE_DOCUMENT,
+    GPS_REQUIREMENT_REQUIRED,
     PRIVACY_NOTICE_DOCUMENT,
     TIME_TRACKING_NOTICE_DOCUMENT,
     required_worker_document_types,
@@ -98,10 +99,23 @@ async def record_worker_onboarding_acknowledgements(
     *,
     worker_id: int,
     company_id: int,
-    gps_notice_enabled: bool = True,
+    gps_notice_enabled: bool | None = None,
 ) -> None:
+    gps_notice_required = bool(gps_notice_enabled)
+    if gps_notice_enabled is None:
+        worker = await db.get(Worker, worker_id)
+        if worker is None:
+            raise ValueError("worker_not_found")
+        gps_requirements = await resolve_worker_gps_site_presence_requirements(
+            db,
+            workers=[worker],
+        )
+        gps_notice_required = (
+            gps_requirements[int(worker.id)].state == GPS_REQUIREMENT_REQUIRED
+        )
+
     for document_type, document_version in WORKER_DOCUMENT_VERSIONS.items():
-        if document_type == GPS_SITE_PRESENCE_NOTICE_DOCUMENT and not gps_notice_enabled:
+        if document_type == GPS_SITE_PRESENCE_NOTICE_DOCUMENT and not gps_notice_required:
             continue
         await record_legal_acceptance(
             db,
@@ -207,10 +221,16 @@ async def get_legal_acceptance_overview(
     )
     worker_notice_states: list[dict[str, object]] = []
     completed_worker_count = 0
+    gps_requirement_counts = {
+        "required": 0,
+        "not_required": 0,
+        "not_applicable": 0,
+    }
     for worker in active_workers:
+        gps_requirement = gps_requirements[int(worker.id)]
         required_documents = required_worker_document_types(
             worker,
-            gps_site_presence_enabled=gps_requirements.get(int(worker.id), False),
+            gps_requirement=gps_requirement,
         )
         accepted_documents = accepted_documents_by_worker.get(int(worker.id), {})
         completed_documents = [
@@ -227,11 +247,18 @@ async def get_legal_acceptance_overview(
             for document_type in required_documents
             if document_type not in completed_documents
         ]
+        gps_requirement_counts[gps_requirement.state] += 1
         state = {
             "worker_id": int(worker.id),
             "required_documents": required_documents,
             "completed_documents": completed_documents,
             "missing_documents": missing_documents,
+            "gps_site_presence_requirement": {
+                "state": gps_requirement.state,
+                "source": gps_requirement.source,
+                "site_gps_capable": gps_requirement.site_gps_capable,
+                "configured_value": gps_requirement.configured_value,
+            },
             "complete": not missing_documents,
         }
         worker_notice_states.append(state)
@@ -248,6 +275,7 @@ async def get_legal_acceptance_overview(
             "completed": completed_worker_count,
             "total": active_worker_total,
         },
+        "gps_site_presence_requirement_counts": gps_requirement_counts,
         "worker_notice_states": worker_notice_states,
         "incomplete_workers": incomplete_workers,
     }

--- a/api/services/legal_acceptance_requirements.py
+++ b/api/services/legal_acceptance_requirements.py
@@ -1,19 +1,36 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import Site, Worker
+from db.models import Company, Site, Worker
 
 
 PRIVACY_NOTICE_DOCUMENT = "privacy_notice"
 TIME_TRACKING_NOTICE_DOCUMENT = "time_tracking_notice"
 GPS_SITE_PRESENCE_NOTICE_DOCUMENT = "gps_site_presence_notice"
 
+GPS_REQUIREMENT_REQUIRED = "required"
+GPS_REQUIREMENT_NOT_REQUIRED = "not_required"
+GPS_REQUIREMENT_NOT_APPLICABLE = "not_applicable"
 
-def gps_site_presence_enabled_for_site(site: Site | None) -> bool:
+
+@dataclass(frozen=True)
+class WorkerGpsSitePresenceRequirement:
+    state: str
+    source: str
+    site_gps_capable: bool
+    configured_value: bool | None
+
+    @property
+    def is_required(self) -> bool:
+        return self.state == GPS_REQUIREMENT_REQUIRED
+
+
+def gps_site_presence_capable_for_site(site: Site | None) -> bool:
     if site is None or not bool(getattr(site, "is_active", False)):
         return False
     return all(
@@ -26,16 +43,111 @@ def gps_site_presence_enabled_for_site(site: Site | None) -> bool:
     )
 
 
+def _time_tracking_notice_required(worker: Worker) -> bool:
+    return bool(getattr(worker, "is_active", False)) and bool(getattr(worker, "time_tracking_enabled", False))
+
+
+def _gps_requirement_from_setting(
+    *,
+    configured_value: bool,
+    source: str,
+    site_gps_capable: bool,
+) -> WorkerGpsSitePresenceRequirement:
+    if not configured_value:
+        return WorkerGpsSitePresenceRequirement(
+            state=GPS_REQUIREMENT_NOT_REQUIRED,
+            source=source,
+            site_gps_capable=site_gps_capable,
+            configured_value=False,
+        )
+    if site_gps_capable:
+        return WorkerGpsSitePresenceRequirement(
+            state=GPS_REQUIREMENT_REQUIRED,
+            source=source,
+            site_gps_capable=True,
+            configured_value=True,
+        )
+    return WorkerGpsSitePresenceRequirement(
+        state=GPS_REQUIREMENT_NOT_APPLICABLE,
+        source=f"{source}_site_not_capable",
+        site_gps_capable=False,
+        configured_value=True,
+    )
+
+
+def resolve_worker_gps_site_presence_requirement(
+    worker: Worker,
+    *,
+    company: Company | None,
+    site: Site | None,
+) -> WorkerGpsSitePresenceRequirement:
+    if not _time_tracking_notice_required(worker):
+        return WorkerGpsSitePresenceRequirement(
+            state=GPS_REQUIREMENT_NOT_APPLICABLE,
+            source="worker_not_tracked",
+            site_gps_capable=gps_site_presence_capable_for_site(site),
+            configured_value=None,
+        )
+
+    site_gps_capable = gps_site_presence_capable_for_site(site)
+    worker_override = getattr(worker, "gps_site_presence_required_override", None)
+    site_setting = getattr(site, "gps_site_presence_required", None) if site is not None else None
+    company_setting = getattr(company, "gps_site_presence_required", None) if company is not None else None
+
+    if worker_override is not None:
+        return _gps_requirement_from_setting(
+            configured_value=bool(worker_override),
+            source="worker_override",
+            site_gps_capable=site_gps_capable,
+        )
+    if site_setting is not None:
+        return _gps_requirement_from_setting(
+            configured_value=bool(site_setting),
+            source="site_setting",
+            site_gps_capable=site_gps_capable,
+        )
+    if company_setting is not None:
+        return _gps_requirement_from_setting(
+            configured_value=bool(company_setting),
+            source="company_setting",
+            site_gps_capable=site_gps_capable,
+        )
+    if site_gps_capable:
+        return WorkerGpsSitePresenceRequirement(
+            state=GPS_REQUIREMENT_REQUIRED,
+            source="fallback_site_gps_capable",
+            site_gps_capable=True,
+            configured_value=None,
+        )
+    return WorkerGpsSitePresenceRequirement(
+        state=GPS_REQUIREMENT_NOT_APPLICABLE,
+        source="fallback_not_gps_capable",
+        site_gps_capable=False,
+        configured_value=None,
+    )
+
+
 def required_worker_document_types(
     worker: Worker,
     *,
-    gps_site_presence_enabled: bool,
+    gps_requirement: WorkerGpsSitePresenceRequirement | None = None,
+    gps_site_presence_enabled: bool | None = None,
 ) -> list[str]:
     required = [PRIVACY_NOTICE_DOCUMENT]
-    if bool(getattr(worker, "is_active", False)) and bool(getattr(worker, "time_tracking_enabled", False)):
+    if _time_tracking_notice_required(worker):
         required.append(TIME_TRACKING_NOTICE_DOCUMENT)
-        if gps_site_presence_enabled:
-            required.append(GPS_SITE_PRESENCE_NOTICE_DOCUMENT)
+
+    effective_gps_requirement = gps_requirement
+    if effective_gps_requirement is None:
+        effective_gps_requirement = WorkerGpsSitePresenceRequirement(
+            state=GPS_REQUIREMENT_REQUIRED if bool(gps_site_presence_enabled) else GPS_REQUIREMENT_NOT_REQUIRED,
+            source="legacy_boolean",
+            site_gps_capable=bool(gps_site_presence_enabled),
+            configured_value=bool(gps_site_presence_enabled),
+        )
+
+    if effective_gps_requirement.is_required:
+        required.append(GPS_SITE_PRESENCE_NOTICE_DOCUMENT)
     return required
 
 
@@ -43,19 +155,33 @@ async def resolve_worker_gps_site_presence_requirements(
     db: AsyncSession,
     *,
     workers: Sequence[Worker],
-) -> dict[int, bool]:
+) -> dict[int, WorkerGpsSitePresenceRequirement]:
     site_ids = {worker.site_id for worker in workers if getattr(worker, "site_id", None) is not None}
-    if not site_ids:
-        return {int(worker.id): False for worker in workers}
+    company_ids = {worker.company_id for worker in workers if getattr(worker, "company_id", None) is not None}
 
-    sites = (
-        await db.execute(
-            select(Site).where(Site.id.in_(site_ids))
-        )
-    ).scalars().all()
-    sites_by_id = {int(site.id): site for site in sites}
+    sites_by_id: dict[int, Site] = {}
+    if site_ids:
+        sites = (
+            await db.execute(
+                select(Site).where(Site.id.in_(site_ids))
+            )
+        ).scalars().all()
+        sites_by_id = {int(site.id): site for site in sites}
+
+    companies_by_id: dict[int, Company] = {}
+    if company_ids:
+        companies = (
+            await db.execute(
+                select(Company).where(Company.id.in_(company_ids))
+            )
+        ).scalars().all()
+        companies_by_id = {int(company.id): company for company in companies}
+
     return {
-        int(worker.id): gps_site_presence_enabled_for_site(sites_by_id.get(worker.site_id))
+        int(worker.id): resolve_worker_gps_site_presence_requirement(
+            worker,
+            company=companies_by_id.get(int(worker.company_id)),
+            site=sites_by_id.get(int(worker.site_id)) if getattr(worker, "site_id", None) is not None else None,
+        )
         for worker in workers
     }
-

--- a/api/services/retention.py
+++ b/api/services/retention.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from fnmatch import fnmatch
+import hashlib
+import inspect
+import json
 from typing import Any
 
 from sqlalchemy import delete, select
@@ -9,7 +13,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import settings
 from api.services.retention_holds import active_retention_hold_entity_ids
+from db.dashboard_tokens import DASHBOARD_TOKEN_PREFIX, dashboard_token_is_expired
 from db.models import AuditLog, TimeEvent, Worker
+
+
+INVITE_RETENTION_PATTERNS = ("inv_*", "owner_inv_*", "partner_inv_*")
+TRANSIENT_STATE_RETENTION_PATTERNS = ("fsm:*",)
+DASHBOARD_TOKEN_RETENTION_PATTERN = f"{DASHBOARD_TOKEN_PREFIX}*"
+
+INVITE_RETENTION_ENTITY_TYPE = "invite_artifact"
+TRANSIENT_STATE_RETENTION_ENTITY_TYPE = "transient_state"
+DASHBOARD_TOKEN_RETENTION_ENTITY_TYPE = "dashboard_token"
 
 
 @dataclass
@@ -22,6 +36,12 @@ class RetentionClassReport:
     anonymized_count: int = 0
     deleted_count: int = 0
     errors: list[str] | None = None
+
+    def add_error(self, error_code: str) -> None:
+        if self.errors is None:
+            self.errors = []
+        if error_code not in self.errors:
+            self.errors.append(error_code)
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -36,6 +56,11 @@ class RetentionClassReport:
         }
 
 
+def retention_key_entity_id(*, entity_type: str, key: str) -> int:
+    digest = hashlib.sha256(f"{entity_type}:{key}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+
+
 def _years_ago(years: int, *, now: datetime) -> datetime:
     return now - timedelta(days=365 * years)
 
@@ -48,6 +73,12 @@ def _effective_destructive_mode(*, destructive: bool | None) -> bool:
     if destructive is None:
         return bool(settings.ENABLE_RETENTION and not settings.RETENTION_DRY_RUN)
     return bool(destructive and settings.ENABLE_RETENTION)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 async def _held_entity_ids(
@@ -89,6 +120,102 @@ async def _candidate_audit_log_ids(
     if company_id is not None:
         stmt = stmt.where(AuditLog.company_id == company_id)
     return list((await db.execute(stmt)).scalars().all())
+
+
+def _decode_redis_value(raw_value: Any) -> str | None:
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, bytes):
+        return raw_value.decode("utf-8")
+    return str(raw_value)
+
+
+def _load_json_value(raw_value: Any) -> dict[str, Any] | None:
+    decoded = _decode_redis_value(raw_value)
+    if decoded is None:
+        return None
+    try:
+        parsed = json.loads(decoded)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def _redis_matching_keys(
+    redis_client: Any,
+    *,
+    patterns: tuple[str, ...],
+) -> list[str]:
+    if redis_client is None:
+        return []
+
+    matched_keys: set[str] = set()
+    scan_iter = getattr(redis_client, "scan_iter", None)
+    if callable(scan_iter):
+        for pattern in patterns:
+            scan_result = scan_iter(match=pattern)
+            if hasattr(scan_result, "__aiter__"):
+                async for key in scan_result:
+                    matched_keys.add(str(key))
+            else:
+                for key in await _maybe_await(scan_result):
+                    matched_keys.add(str(key))
+        return sorted(matched_keys)
+
+    keys_method = getattr(redis_client, "keys", None)
+    if callable(keys_method):
+        for pattern in patterns:
+            for key in await _maybe_await(keys_method(pattern)):
+                matched_keys.add(str(key))
+        return sorted(matched_keys)
+
+    values = getattr(redis_client, "values", None)
+    if isinstance(values, dict):
+        for key in values:
+            if any(fnmatch(str(key), pattern) for pattern in patterns):
+                matched_keys.add(str(key))
+    return sorted(matched_keys)
+
+
+async def _redis_get(redis_client: Any, key: str) -> Any:
+    get_method = getattr(redis_client, "get", None)
+    if not callable(get_method):
+        values = getattr(redis_client, "values", None)
+        if isinstance(values, dict):
+            return values.get(key)
+        return None
+    return await _maybe_await(get_method(key))
+
+
+async def _redis_ttl(redis_client: Any, key: str) -> int | None:
+    ttl_method = getattr(redis_client, "ttl", None)
+    if callable(ttl_method):
+        ttl_value = await _maybe_await(ttl_method(key))
+        return int(ttl_value) if ttl_value is not None else None
+
+    ttls = getattr(redis_client, "ttls", None)
+    if isinstance(ttls, dict):
+        ttl_value = ttls.get(key)
+        return int(ttl_value) if ttl_value is not None else None
+    return None
+
+
+async def _redis_delete(redis_client: Any, key: str) -> int:
+    delete_method = getattr(redis_client, "delete", None)
+    if callable(delete_method):
+        deleted = await _maybe_await(delete_method(key))
+        if isinstance(deleted, bool):
+            return 1 if deleted else 0
+        return int(deleted or 0)
+
+    values = getattr(redis_client, "values", None)
+    if isinstance(values, dict) and key in values:
+        values.pop(key, None)
+        ttls = getattr(redis_client, "ttls", None)
+        if isinstance(ttls, dict):
+            ttls.pop(key, None)
+        return 1
+    return 0
 
 
 async def _report_for_time_events(
@@ -148,8 +275,145 @@ async def _report_for_audit_logs(
     return report
 
 
-def _placeholder_report(name: str) -> RetentionClassReport:
-    return RetentionClassReport(name=name)
+async def _report_for_invites(
+    db: AsyncSession,
+    *,
+    redis_client: Any,
+    now: datetime,
+    company_id: int | None,
+    destructive: bool,
+) -> RetentionClassReport:
+    report = RetentionClassReport(name="invites")
+    keys = await _redis_matching_keys(redis_client, patterns=INVITE_RETENTION_PATTERNS)
+    if redis_client is None:
+        report.add_error("redis_unavailable")
+        return report
+
+    held_ids = await _held_entity_ids(db, entity_type=INVITE_RETENTION_ENTITY_TYPE, now=now)
+    deletable_keys: list[str] = []
+    for key in keys:
+        payload = _load_json_value(await _redis_get(redis_client, key)) or {}
+        related_company_id = payload.get("company_id") or payload.get("general_contractor_company_id")
+        if company_id is not None and int(related_company_id or 0) != company_id:
+            continue
+
+        ttl = await _redis_ttl(redis_client, key)
+        if ttl is None:
+            report.add_error("invite_ttl_unavailable")
+            continue
+        if ttl != -1:
+            continue
+
+        report.candidate_count += 1
+        entity_id = retention_key_entity_id(entity_type=INVITE_RETENTION_ENTITY_TYPE, key=key)
+        if entity_id in held_ids:
+            report.held_count += 1
+            continue
+        deletable_keys.append(key)
+
+    if not destructive or not deletable_keys:
+        report.skipped_count = len(deletable_keys)
+        return report
+
+    for key in deletable_keys:
+        report.deleted_count += await _redis_delete(redis_client, key)
+    return report
+
+
+async def _report_for_transient_states(
+    db: AsyncSession,
+    *,
+    redis_client: Any,
+    now: datetime,
+    company_id: int | None,
+    destructive: bool,
+) -> RetentionClassReport:
+    report = RetentionClassReport(name="transient_states")
+    if redis_client is None:
+        report.add_error("redis_unavailable")
+        return report
+    if company_id is not None:
+        report.add_error("company_scope_not_supported")
+        return report
+
+    keys = await _redis_matching_keys(redis_client, patterns=TRANSIENT_STATE_RETENTION_PATTERNS)
+    held_ids = await _held_entity_ids(db, entity_type=TRANSIENT_STATE_RETENTION_ENTITY_TYPE, now=now)
+    deletable_keys: list[str] = []
+    for key in keys:
+        ttl = await _redis_ttl(redis_client, key)
+        if ttl is None:
+            report.add_error("transient_state_ttl_unavailable")
+            continue
+        if ttl != -1:
+            continue
+
+        report.candidate_count += 1
+        entity_id = retention_key_entity_id(entity_type=TRANSIENT_STATE_RETENTION_ENTITY_TYPE, key=key)
+        if entity_id in held_ids:
+            report.held_count += 1
+            continue
+        deletable_keys.append(key)
+
+    if not destructive or not deletable_keys:
+        report.skipped_count = len(deletable_keys)
+        return report
+
+    for key in deletable_keys:
+        report.deleted_count += await _redis_delete(redis_client, key)
+    return report
+
+
+async def _report_for_dashboard_tokens(
+    db: AsyncSession,
+    *,
+    redis_client: Any,
+    now: datetime,
+    company_id: int | None,
+    destructive: bool,
+) -> RetentionClassReport:
+    report = RetentionClassReport(name="dashboard_tokens")
+    if redis_client is None:
+        report.add_error("redis_unavailable")
+        return report
+
+    keys = await _redis_matching_keys(redis_client, patterns=(DASHBOARD_TOKEN_RETENTION_PATTERN,))
+    held_ids = await _held_entity_ids(db, entity_type=DASHBOARD_TOKEN_RETENTION_ENTITY_TYPE, now=now)
+    deletable_keys: list[str] = []
+    for key in keys:
+        raw_value = await _redis_get(redis_client, key)
+        payload = _load_json_value(raw_value) or {}
+        payload_company_id = payload.get("company_id")
+        if company_id is not None and int(payload_company_id or 0) != company_id:
+            continue
+
+        ttl = await _redis_ttl(redis_client, key)
+        if ttl is None:
+            report.add_error("dashboard_token_ttl_unavailable")
+            continue
+
+        token_expired = False
+        try:
+            token_expired = dashboard_token_is_expired(raw_value, now=now)
+        except ValueError:
+            token_expired = True
+
+        if ttl != -1 and not token_expired:
+            continue
+
+        report.candidate_count += 1
+        entity_id = retention_key_entity_id(entity_type=DASHBOARD_TOKEN_RETENTION_ENTITY_TYPE, key=key)
+        if entity_id in held_ids:
+            report.held_count += 1
+            continue
+        deletable_keys.append(key)
+
+    if not destructive or not deletable_keys:
+        report.skipped_count = len(deletable_keys)
+        return report
+
+    for key in deletable_keys:
+        report.deleted_count += await _redis_delete(redis_client, key)
+    return report
 
 
 def _reports_to_by_class(reports: list[RetentionClassReport]) -> dict[str, dict[str, Any]]:
@@ -177,6 +441,7 @@ async def run_retention_cycle(
     now: datetime | None = None,
     company_id: int | None = None,
     destructive: bool | None = None,
+    redis_client: Any | None = None,
 ) -> dict[str, Any]:
     effective_now = _effective_now(now)
     destructive_mode = _effective_destructive_mode(destructive=destructive)
@@ -193,9 +458,27 @@ async def run_retention_cycle(
             company_id=company_id,
             destructive=destructive_mode,
         ),
-        _placeholder_report("invites"),
-        _placeholder_report("transient_states"),
-        _placeholder_report("logs"),
+        await _report_for_invites(
+            db,
+            redis_client=redis_client,
+            now=effective_now,
+            company_id=company_id,
+            destructive=destructive_mode,
+        ),
+        await _report_for_transient_states(
+            db,
+            redis_client=redis_client,
+            now=effective_now,
+            company_id=company_id,
+            destructive=destructive_mode,
+        ),
+        await _report_for_dashboard_tokens(
+            db,
+            redis_client=redis_client,
+            now=effective_now,
+            company_id=company_id,
+            destructive=destructive_mode,
+        ),
     ]
 
     if destructive_mode:

--- a/api/services/retention_holds.py
+++ b/api/services/retention_holds.py
@@ -45,6 +45,8 @@ def normalized_retention_hold_view(
 
 
 def _active_hold_filter(*, now: datetime):
+    # Canonical fields win for all new rows. Legacy fields remain readable only
+    # when old data still has not been normalized into the canonical columns.
     return and_(
         RetentionHold.is_active.is_(True),
         or_(
@@ -75,11 +77,9 @@ async def place_retention_hold(
         entity_id=entity_id,
         hold_type=hold_type,
         hold_reason=normalized_reason,
-        reason=normalized_reason,
         company_id=company_id,
         held_by_worker_id=held_by_worker_id,
         hold_until=hold_until,
-        expires_at=hold_until,
         is_active=True,
     )
     db.add(hold)

--- a/bot/config.py
+++ b/bot/config.py
@@ -2,11 +2,13 @@ import json
 from typing import Any
 
 from pydantic import field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from bot.utils.access import normalize_usernames
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
     BOT_TOKEN: str
     REDIS_URL: str = "redis://redis:6379/0"
     DATABASE_URL: str = "sqlite+aiosqlite:///./bauclock.db"
@@ -56,9 +58,5 @@ class Settings(BaseSettings):
         return self.BOT_ROLE == "platform" or (
             bool(bot_username) and bot_username == platform_username
         )
-    
-    class Config:
-        env_file = ".env"
-        extra = "ignore"
-        
+
 settings = Settings()

--- a/bot/handlers/worker.py
+++ b/bot/handlers/worker.py
@@ -403,7 +403,6 @@ async def handle_language_selection(callback: CallbackQuery, state: FSMContext, 
         session,
         worker_id=new_worker.id,
         company_id=new_worker.company_id,
-        gps_notice_enabled=True,
     )
     await session.commit()
     

--- a/db/migrations/versions/b7f2c1e4d5a6_add_phase2_gps_and_arbzg_findings.py
+++ b/db/migrations/versions/b7f2c1e4d5a6_add_phase2_gps_and_arbzg_findings.py
@@ -1,0 +1,123 @@
+"""add phase 2 gps policy flags and arbzg findings
+
+Revision ID: b7f2c1e4d5a6
+Revises: a9d1e4c7b2f3
+Create Date: 2026-04-23 10:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b7f2c1e4d5a6"
+down_revision: Union[str, Sequence[str], None] = "a9d1e4c7b2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _tables() -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return set(inspector.get_table_names())
+
+
+def _create_table_if_missing(
+    table_name: str,
+    *columns,
+    indexes: list[tuple[str, list[str], bool]] | None = None,
+) -> None:
+    if table_name in _tables():
+        return
+    op.create_table(table_name, *columns)
+    for index_name, index_columns, unique in indexes or []:
+        op.create_index(index_name, table_name, index_columns, unique=unique)
+
+
+def upgrade() -> None:
+    company_columns = _columns("companies")
+    with op.batch_alter_table("companies", schema=None) as batch_op:
+        if "gps_site_presence_required" not in company_columns:
+            batch_op.add_column(sa.Column("gps_site_presence_required", sa.Boolean(), nullable=True))
+
+    site_columns = _columns("sites")
+    with op.batch_alter_table("sites", schema=None) as batch_op:
+        if "gps_site_presence_required" not in site_columns:
+            batch_op.add_column(sa.Column("gps_site_presence_required", sa.Boolean(), nullable=True))
+
+    worker_columns = _columns("workers")
+    with op.batch_alter_table("workers", schema=None) as batch_op:
+        if "gps_site_presence_required_override" not in worker_columns:
+            batch_op.add_column(sa.Column("gps_site_presence_required_override", sa.Boolean(), nullable=True))
+
+    _create_table_if_missing(
+        "arbzg_findings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("company_id", sa.Integer(), nullable=False),
+        sa.Column("worker_id", sa.Integer(), nullable=False),
+        sa.Column("target_date", sa.Date(), nullable=False),
+        sa.Column("finding_code", sa.String(length=64), nullable=False),
+        sa.Column("severity", sa.String(length=16), nullable=False),
+        sa.Column("state", sa.String(length=16), nullable=False, server_default="open"),
+        sa.Column("state_reason", sa.String(length=255), nullable=True),
+        sa.Column("created_by_worker_id", sa.Integer(), nullable=True),
+        sa.Column("updated_by_worker_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["company_id"], ["companies.id"]),
+        sa.ForeignKeyConstraint(["worker_id"], ["workers.id"]),
+        sa.ForeignKeyConstraint(["created_by_worker_id"], ["workers.id"]),
+        sa.ForeignKeyConstraint(["updated_by_worker_id"], ["workers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "company_id",
+            "worker_id",
+            "target_date",
+            "finding_code",
+            name="uq_arbzg_findings_company_worker_date_code",
+        ),
+        indexes=[
+            (op.f("ix_arbzg_findings_id"), ["id"], False),
+            (op.f("ix_arbzg_findings_company_id"), ["company_id"], False),
+            (op.f("ix_arbzg_findings_worker_id"), ["worker_id"], False),
+            (op.f("ix_arbzg_findings_target_date"), ["target_date"], False),
+            (op.f("ix_arbzg_findings_finding_code"), ["finding_code"], False),
+        ],
+    )
+
+
+def downgrade() -> None:
+    if "arbzg_findings" in _tables():
+        op.drop_index(op.f("ix_arbzg_findings_finding_code"), table_name="arbzg_findings")
+        op.drop_index(op.f("ix_arbzg_findings_target_date"), table_name="arbzg_findings")
+        op.drop_index(op.f("ix_arbzg_findings_worker_id"), table_name="arbzg_findings")
+        op.drop_index(op.f("ix_arbzg_findings_company_id"), table_name="arbzg_findings")
+        op.drop_index(op.f("ix_arbzg_findings_id"), table_name="arbzg_findings")
+        op.drop_table("arbzg_findings")
+
+    worker_columns = _columns("workers")
+    with op.batch_alter_table("workers", schema=None) as batch_op:
+        if "gps_site_presence_required_override" in worker_columns:
+            batch_op.drop_column("gps_site_presence_required_override")
+
+    site_columns = _columns("sites")
+    with op.batch_alter_table("sites", schema=None) as batch_op:
+        if "gps_site_presence_required" in site_columns:
+            batch_op.drop_column("gps_site_presence_required")
+
+    company_columns = _columns("companies")
+    with op.batch_alter_table("companies", schema=None) as batch_op:
+        if "gps_site_presence_required" in company_columns:
+            batch_op.drop_column("gps_site_presence_required")

--- a/db/models.py
+++ b/db/models.py
@@ -1,5 +1,5 @@
 import enum
-from sqlalchemy import Column, Integer, String, Boolean, Date, DateTime, Float, ForeignKey, Enum, Text, JSON
+from sqlalchemy import Column, Integer, String, Boolean, Date, DateTime, Float, ForeignKey, Enum, Text, JSON, UniqueConstraint
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
 from db.security import encrypt_string, decrypt_string, hash_string
@@ -68,6 +68,13 @@ class CalendarEventType(str, enum.Enum):
     PUBLIC_HOLIDAY = "public_holiday"
     NON_WORKING_DAY = "non_working_day"
 
+
+class ArbzgFindingState(str, enum.Enum):
+    OPEN = "open"
+    REVIEWED = "reviewed"
+    RESOLVED = "resolved"
+    DISMISSED = "dismissed"
+
 class LanguageSupport(str, enum.Enum):
     DE = "de"
     UK = "uk"
@@ -92,6 +99,7 @@ class Company(Base):
     phone = Column(String, nullable=True)
     email = Column(String, nullable=True)
     website = Column(String, nullable=True)
+    gps_site_presence_required = Column(Boolean, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     sites = relationship("Site", back_populates="company")
@@ -142,6 +150,7 @@ class Site(Base):
     lat = Column(Float, nullable=True)
     lon = Column(Float, nullable=True)
     radius_m = Column(Float, nullable=True)
+    gps_site_presence_required = Column(Boolean, nullable=True)
 
     company = relationship("Company", back_populates="sites")
     workers = relationship("Worker", back_populates="site")
@@ -213,6 +222,7 @@ class Worker(Base):
     )
     can_view_dashboard = Column(Boolean, default=False)
     time_tracking_enabled = Column(Boolean, nullable=False, default=True, server_default="1")
+    gps_site_presence_required_override = Column(Boolean, nullable=True)
     is_active = Column(Boolean, default=True)
     gdpr_consent_at = Column(DateTime(timezone=True), nullable=True)
 
@@ -402,6 +412,41 @@ class LegalAcceptanceLog(Base):
     document_version = Column(String(32), nullable=False)
     action_type = Column(String(32), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class ArbzgFinding(Base):
+    __tablename__ = "arbzg_findings"
+    __table_args__ = (
+        UniqueConstraint(
+            "company_id",
+            "worker_id",
+            "target_date",
+            "finding_code",
+            name="uq_arbzg_findings_company_worker_date_code",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("companies.id"), nullable=False, index=True)
+    worker_id = Column(Integer, ForeignKey("workers.id"), nullable=False, index=True)
+    target_date = Column(Date, nullable=False, index=True)
+    finding_code = Column(String(64), nullable=False, index=True)
+    severity = Column(String(16), nullable=False)
+    state = Column(
+        String(16),
+        nullable=False,
+        default=ArbzgFindingState.OPEN.value,
+        server_default=ArbzgFindingState.OPEN.value,
+    )
+    state_reason = Column(String(255), nullable=True)
+    created_by_worker_id = Column(Integer, ForeignKey("workers.id"), nullable=True)
+    updated_by_worker_id = Column(Integer, ForeignKey("workers.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
 
 class RetentionHold(Base):

--- a/tests/test_legal_hardening.py
+++ b/tests/test_legal_hardening.py
@@ -1,7 +1,9 @@
 import asyncio
+import json
 import os
 import sys
 from datetime import date, datetime, timedelta, timezone
+from fnmatch import fnmatch
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -31,6 +33,7 @@ import api.routers.dashboard as dashboard_router
 from api.config import settings
 import api.services.datev_export as datev_export_service
 from api.services.arbzg_reporting import build_company_arbzg_day_report
+from api.services.arbzg_reviews import list_arbzg_findings, open_arbzg_finding, set_arbzg_finding_state
 from api.services.arbzg_policy import get_worker_arbzg_flags
 from api.services.audited_changes import (
     apply_audited_payment_update,
@@ -51,18 +54,40 @@ from api.services.retention_holds import (
     place_retention_hold,
     release_retention_holds,
 )
-from api.services.retention import run_retention_cycle
+from api.services.retention import (
+    DASHBOARD_TOKEN_RETENTION_ENTITY_TYPE,
+    INVITE_RETENTION_ENTITY_TYPE,
+    TRANSIENT_STATE_RETENTION_ENTITY_TYPE,
+    retention_key_entity_id,
+    run_retention_cycle,
+)
 from db.dashboard_tokens import build_dashboard_token_payload, dashboard_token_key
-from db.models import AuditLog, Base, BillingType, Company, EventType, LegalAcceptanceLog, MonthlyAdjustment, Payment, PaymentStatus, RetentionHold, Site, TimeEvent, Worker, WorkerAccessRole, WorkerType
+from db.models import ArbzgFinding, AuditLog, Base, BillingType, Company, EventType, LegalAcceptanceLog, MonthlyAdjustment, Payment, PaymentStatus, RetentionHold, Site, TimeEvent, Worker, WorkerAccessRole, WorkerType
 from db.time_corrections import apply_manual_time_correction
 
 
 class FakeRedis:
-    def __init__(self, values: dict[str, str | None]):
-        self.values = values
+    def __init__(self, values: dict[str, str | None], *, ttls: dict[str, int] | None = None):
+        self.values = dict(values)
+        self.ttls = dict(ttls or {})
 
     async def get(self, key: str) -> str | None:
         return self.values.get(key)
+
+    async def keys(self, pattern: str) -> list[str]:
+        return [key for key in self.values if fnmatch(key, pattern)]
+
+    async def ttl(self, key: str) -> int:
+        if key not in self.values:
+            return -2
+        return self.ttls.get(key, -1)
+
+    async def delete(self, key: str) -> int:
+        if key not in self.values:
+            return 0
+        self.values.pop(key, None)
+        self.ttls.pop(key, None)
+        return 1
 
 
 def run_db_test(test_coro):
@@ -83,11 +108,17 @@ def run_db_test(test_coro):
     asyncio.run(runner())
 
 
-async def seed_company(session, suffix: str) -> Company:
+async def seed_company(
+    session,
+    suffix: str,
+    *,
+    gps_site_presence_required: bool | None = None,
+) -> Company:
     company = Company(
         name=f"Company {suffix}",
         owner_telegram_id_enc=f"owner_enc_{suffix}",
         owner_telegram_id_hash=f"owner_hash_{suffix}",
+        gps_site_presence_required=gps_site_presence_required,
     )
     session.add(company)
     await session.flush()
@@ -102,6 +133,7 @@ async def seed_site(
     lat: float | None = None,
     lon: float | None = None,
     radius_m: float | None = None,
+    gps_site_presence_required: bool | None = None,
 ) -> Site:
     site = Site(
         company_id=company_id,
@@ -111,6 +143,7 @@ async def seed_site(
         lat=lat,
         lon=lon,
         radius_m=radius_m,
+        gps_site_presence_required=gps_site_presence_required,
     )
     session.add(site)
     await session.flush()
@@ -126,6 +159,7 @@ async def seed_worker(
     access_role: str = WorkerAccessRole.WORKER.value,
     site_id: int | None = None,
     time_tracking_enabled: bool = True,
+    gps_site_presence_required_override: bool | None = None,
 ) -> Worker:
     worker = Worker(
         company_id=company_id,
@@ -138,6 +172,7 @@ async def seed_worker(
         can_view_dashboard=can_view_dashboard,
         access_role=access_role,
         time_tracking_enabled=time_tracking_enabled,
+        gps_site_presence_required_override=gps_site_presence_required_override,
         is_active=True,
     )
     session.add(worker)
@@ -621,6 +656,11 @@ def test_legal_acceptance_completion_uses_worker_specific_requirements():
 
         assert overview_a["company_documents_complete"] is True
         assert overview_a["worker_notice_completion"] == {"completed": 2, "total": 3}
+        assert overview_a["gps_site_presence_requirement_counts"] == {
+            "required": 1,
+            "not_required": 0,
+            "not_applicable": 2,
+        }
         assert overview_a["incomplete_workers"] == [
             {
                 "worker_id": gps_worker.id,
@@ -634,6 +674,12 @@ def test_legal_acceptance_completion_uses_worker_specific_requirements():
                     "time_tracking_notice",
                 ],
                 "missing_documents": ["gps_site_presence_notice"],
+                "gps_site_presence_requirement": {
+                    "state": "required",
+                    "source": "fallback_site_gps_capable",
+                    "site_gps_capable": True,
+                    "configured_value": None,
+                },
                 "complete": False,
             }
         ]
@@ -644,9 +690,153 @@ def test_legal_acceptance_completion_uses_worker_specific_requirements():
         )
         assert regular_worker_state["complete"] is True
         assert regular_worker_state["missing_documents"] == []
+        assert regular_worker_state["gps_site_presence_requirement"]["state"] == "not_applicable"
 
         assert overview_b["worker_notice_completion"] == {"completed": 1, "total": 1}
         assert overview_b["incomplete_workers"] == []
+
+    run_db_test(run_test)
+
+
+def test_legal_acceptance_gps_requirement_precedence():
+    async def run_test(session):
+        company = await seed_company(
+            session,
+            "gps-precedence",
+            gps_site_presence_required=False,
+        )
+        site_required = await seed_site(
+            session,
+            company.id,
+            "gps-precedence-required",
+            lat=52.52,
+            lon=13.40,
+            radius_m=120,
+            gps_site_presence_required=True,
+        )
+        site_optional = await seed_site(
+            session,
+            company.id,
+            "gps-precedence-optional",
+            lat=52.53,
+            lon=13.41,
+            radius_m=120,
+            gps_site_presence_required=False,
+        )
+        site_default = await seed_site(
+            session,
+            company.id,
+            "gps-precedence-default",
+            lat=52.54,
+            lon=13.42,
+            radius_m=120,
+        )
+        owner = await seed_worker(
+            session,
+            company.id,
+            "gps-precedence-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        site_required_worker = await seed_worker(
+            session,
+            company.id,
+            "gps-site-required",
+            site_id=site_required.id,
+        )
+        company_opt_out_worker = await seed_worker(
+            session,
+            company.id,
+            "gps-company-opt-out",
+            site_id=site_default.id,
+        )
+        worker_override_false = await seed_worker(
+            session,
+            company.id,
+            "gps-worker-false",
+            site_id=site_required.id,
+            gps_site_presence_required_override=False,
+        )
+        worker_override_true = await seed_worker(
+            session,
+            company.id,
+            "gps-worker-true",
+            site_id=site_optional.id,
+            gps_site_presence_required_override=True,
+        )
+
+        await record_company_onboarding_acceptance(
+            session,
+            actor_worker_id=owner.id,
+            company_id=company.id,
+        )
+        await record_legal_acceptance(
+            session,
+            actor_type="worker",
+            actor_id=owner.id,
+            company_id=company.id,
+            document_type="privacy_notice",
+            document_version="2026-04-de-v1",
+            action_type="acknowledged",
+        )
+        for worker in [
+            site_required_worker,
+            company_opt_out_worker,
+            worker_override_false,
+            worker_override_true,
+        ]:
+            await record_worker_onboarding_acknowledgements(
+                session,
+                worker_id=worker.id,
+                company_id=company.id,
+                gps_notice_enabled=False,
+            )
+        await session.commit()
+
+        overview = await get_legal_acceptance_overview(session, company_id=company.id)
+        states = {
+            item["worker_id"]: item
+            for item in overview["worker_notice_states"]
+        }
+
+        assert states[site_required_worker.id]["gps_site_presence_requirement"] == {
+            "state": "required",
+            "source": "site_setting",
+            "site_gps_capable": True,
+            "configured_value": True,
+        }
+        assert states[site_required_worker.id]["complete"] is False
+        assert states[site_required_worker.id]["missing_documents"] == ["gps_site_presence_notice"]
+
+        assert states[company_opt_out_worker.id]["gps_site_presence_requirement"] == {
+            "state": "not_required",
+            "source": "company_setting",
+            "site_gps_capable": True,
+            "configured_value": False,
+        }
+        assert states[company_opt_out_worker.id]["complete"] is True
+
+        assert states[worker_override_false.id]["gps_site_presence_requirement"] == {
+            "state": "not_required",
+            "source": "worker_override",
+            "site_gps_capable": True,
+            "configured_value": False,
+        }
+        assert states[worker_override_false.id]["complete"] is True
+
+        assert states[worker_override_true.id]["gps_site_presence_requirement"] == {
+            "state": "required",
+            "source": "worker_override",
+            "site_gps_capable": True,
+            "configured_value": True,
+        }
+        assert states[worker_override_true.id]["complete"] is False
+        assert overview["gps_site_presence_requirement_counts"] == {
+            "required": 2,
+            "not_required": 2,
+            "not_applicable": 1,
+        }
 
     run_db_test(run_test)
 
@@ -852,8 +1042,8 @@ def test_retention_hold_normalization_supports_legacy_and_canonical_rows():
         ) is True
 
         stored_canonical = await session.get(RetentionHold, canonical_hold.id)
-        assert stored_canonical.reason == "Canonical dispute hold"
-        assert stored_canonical.expires_at.isoformat().startswith("2026-05-01T00:00:00")
+        assert stored_canonical.reason is None
+        assert stored_canonical.expires_at is None
 
     run_db_test(run_test)
 
@@ -933,6 +1123,155 @@ def test_retention_cycle_only_deletes_in_explicit_destructive_mode(monkeypatch):
         assert await session.get(TimeEvent, held_event.id) is not None
         assert await session.get(TimeEvent, deletable_event.id) is None
         assert await session.get(AuditLog, recent_audit.id) is not None
+
+    run_db_test(run_test)
+
+
+def test_retention_cycle_reports_and_cleans_invites_and_dashboard_tokens(monkeypatch):
+    async def run_test(session):
+        monkeypatch.setattr(settings, "ENABLE_RETENTION", True)
+        monkeypatch.setattr(settings, "RETENTION_DRY_RUN", True)
+        monkeypatch.setattr(settings, "DATA_RETENTION_YEARS_TIME_EVENTS", 3)
+        monkeypatch.setattr(settings, "DATA_RETENTION_YEARS_AUDIT_LOGS", 5)
+
+        company = await seed_company(session, "retention-redis")
+        actor = await seed_worker(
+            session,
+            company.id,
+            "retention-redis-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        held_invite_key = "inv_held_company_worker"
+        deletable_invite_key = "partner_inv_cleanup"
+        expired_dashboard_token_key = dashboard_token_key("expired-dashboard-token")
+        redis_client = FakeRedis(
+            {
+                held_invite_key: json.dumps({"company_id": company.id}),
+                deletable_invite_key: json.dumps({"general_contractor_company_id": company.id}),
+                expired_dashboard_token_key: build_dashboard_token_payload(
+                    worker_id=actor.id,
+                    company_id=company.id,
+                    issued_at=datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc),
+                ),
+            },
+            ttls={
+                held_invite_key: -1,
+                deletable_invite_key: -1,
+                expired_dashboard_token_key: 600,
+            },
+        )
+        await place_retention_hold(
+            session,
+            entity_type=INVITE_RETENTION_ENTITY_TYPE,
+            entity_id=retention_key_entity_id(
+                entity_type=INVITE_RETENTION_ENTITY_TYPE,
+                key=held_invite_key,
+            ),
+            hold_reason="Pending compliance review",
+            company_id=company.id,
+            held_by_worker_id=actor.id,
+            hold_until=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        await session.commit()
+
+        dry_run_report = await run_retention_cycle(
+            session,
+            now=datetime(2026, 4, 21, tzinfo=timezone.utc),
+            company_id=company.id,
+            destructive=False,
+            redis_client=redis_client,
+        )
+
+        assert dry_run_report["by_class"]["invites"]["candidate_count"] == 2
+        assert dry_run_report["by_class"]["invites"]["held_count"] == 1
+        assert dry_run_report["by_class"]["invites"]["skipped_count"] == 1
+        assert dry_run_report["by_class"]["dashboard_tokens"]["candidate_count"] == 1
+        assert dry_run_report["by_class"]["dashboard_tokens"]["deleted_count"] == 0
+        assert held_invite_key in redis_client.values
+        assert deletable_invite_key in redis_client.values
+        assert expired_dashboard_token_key in redis_client.values
+
+        destructive_report = await run_retention_cycle(
+            session,
+            now=datetime(2026, 4, 21, tzinfo=timezone.utc),
+            company_id=company.id,
+            destructive=True,
+            redis_client=redis_client,
+        )
+
+        assert destructive_report["by_class"]["invites"]["held_count"] == 1
+        assert destructive_report["by_class"]["invites"]["deleted_count"] == 1
+        assert destructive_report["by_class"]["dashboard_tokens"]["deleted_count"] == 1
+        assert held_invite_key in redis_client.values
+        assert deletable_invite_key not in redis_client.values
+        assert expired_dashboard_token_key not in redis_client.values
+
+    run_db_test(run_test)
+
+
+def test_retention_cycle_reports_and_cleans_transient_states(monkeypatch):
+    async def run_test(session):
+        monkeypatch.setattr(settings, "ENABLE_RETENTION", True)
+        monkeypatch.setattr(settings, "RETENTION_DRY_RUN", True)
+
+        company = await seed_company(session, "retention-fsm")
+        actor = await seed_worker(
+            session,
+            company.id,
+            "retention-fsm-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        held_state_key = "fsm:bot:chat:1:user:1:state"
+        deletable_state_key = "fsm:bot:chat:2:user:2:data"
+        redis_client = FakeRedis(
+            {
+                held_state_key: "state_payload",
+                deletable_state_key: "data_payload",
+            },
+            ttls={
+                held_state_key: -1,
+                deletable_state_key: -1,
+            },
+        )
+        await place_retention_hold(
+            session,
+            entity_type=TRANSIENT_STATE_RETENTION_ENTITY_TYPE,
+            entity_id=retention_key_entity_id(
+                entity_type=TRANSIENT_STATE_RETENTION_ENTITY_TYPE,
+                key=held_state_key,
+            ),
+            hold_reason="Investigating state corruption",
+            company_id=company.id,
+            held_by_worker_id=actor.id,
+            hold_until=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        await session.commit()
+
+        dry_run_report = await run_retention_cycle(
+            session,
+            now=datetime(2026, 4, 21, tzinfo=timezone.utc),
+            destructive=False,
+            redis_client=redis_client,
+        )
+        assert dry_run_report["by_class"]["transient_states"]["candidate_count"] == 2
+        assert dry_run_report["by_class"]["transient_states"]["held_count"] == 1
+        assert dry_run_report["by_class"]["transient_states"]["skipped_count"] == 1
+        assert held_state_key in redis_client.values
+        assert deletable_state_key in redis_client.values
+
+        destructive_report = await run_retention_cycle(
+            session,
+            now=datetime(2026, 4, 21, tzinfo=timezone.utc),
+            destructive=True,
+            redis_client=redis_client,
+        )
+        assert destructive_report["by_class"]["transient_states"]["deleted_count"] == 1
+        assert held_state_key in redis_client.values
+        assert deletable_state_key not in redis_client.values
 
     run_db_test(run_test)
 
@@ -1140,7 +1479,7 @@ def test_arbzg_company_day_report_summarizes_codes():
         assert report["summary_counts"]["break_reminder_after_6h"] == 1
         assert report["summary_counts"]["rest_period_warning"] == 1
         assert flagged_codes == {"break_reminder_after_6h", "rest_period_warning"}
-        assert flagged_item["review_state"] == "unreviewed"
+        assert flagged_item["review_state"] == "open"
         assert clean_item["flags"] == []
         assert clean_item["review_state"] == "clean"
 
@@ -1193,6 +1532,240 @@ def test_arbzg_company_day_report_returns_clean_results_without_flags():
         assert report["flagged_workers"] == 0
         assert report["summary_counts"] == {}
         assert report["items"][0]["flags"] == []
+
+    run_db_test(run_test)
+
+
+def test_arbzg_review_workflow_persists_and_overlays_report():
+    async def run_test(session):
+        company = await seed_company(session, "arbzg-review")
+        site = await seed_site(session, company.id, "arbzg-review")
+        owner = await seed_worker(
+            session,
+            company.id,
+            "arbzg-review-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        worker = await seed_worker(session, company.id, "arbzg-review-worker", site_id=site.id)
+        other_company = await seed_company(session, "arbzg-review-other")
+        other_worker = await seed_worker(session, other_company.id, "arbzg-review-other-worker")
+        target_day = date(2026, 4, 21)
+        session.add_all(
+            [
+                TimeEvent(
+                    worker_id=worker.id,
+                    site_id=site.id,
+                    event_type=EventType.CHECKOUT,
+                    timestamp=datetime(2026, 4, 20, 23, 30, tzinfo=timezone.utc),
+                ),
+                TimeEvent(
+                    worker_id=worker.id,
+                    site_id=site.id,
+                    event_type=EventType.CHECKIN,
+                    timestamp=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
+                ),
+            ]
+        )
+        await session.flush()
+
+        break_finding = await open_arbzg_finding(
+            session,
+            company_id=company.id,
+            worker_id=worker.id,
+            target_date=target_day,
+            finding_code="break_reminder_after_6h",
+            severity="warning",
+            actor_worker_id=owner.id,
+        )
+        rest_finding = await open_arbzg_finding(
+            session,
+            company_id=company.id,
+            worker_id=worker.id,
+            target_date=target_day,
+            finding_code="rest_period_warning",
+            severity="critical",
+            actor_worker_id=owner.id,
+        )
+        await set_arbzg_finding_state(
+            session,
+            finding_id=break_finding.id,
+            company_id=company.id,
+            state="reviewed",
+            actor_worker_id=owner.id,
+        )
+        await set_arbzg_finding_state(
+            session,
+            finding_id=break_finding.id,
+            company_id=company.id,
+            state="resolved",
+            actor_worker_id=owner.id,
+            reason="Break confirmed after manual review",
+        )
+        await set_arbzg_finding_state(
+            session,
+            finding_id=rest_finding.id,
+            company_id=company.id,
+            state="dismissed",
+            actor_worker_id=owner.id,
+            reason="Previous day checkout corrected",
+        )
+        await session.commit()
+
+        findings = await list_arbzg_findings(
+            session,
+            company_id=company.id,
+            target_date=target_day,
+        )
+        findings_by_code = {
+            finding["finding_code"]: finding
+            for finding in findings
+        }
+        report = await build_company_arbzg_day_report(
+            session,
+            company_id=company.id,
+            target_day=target_day,
+            now=datetime(2026, 4, 21, 15, 30, tzinfo=timezone.utc),
+        )
+        flagged_item = next(item for item in report["items"] if item["worker_id"] == worker.id)
+        review_states = {
+            flag["code"]: flag["review_state"]
+            for flag in flagged_item["flags"]
+        }
+
+        assert findings_by_code["break_reminder_after_6h"]["state"] == "resolved"
+        assert findings_by_code["break_reminder_after_6h"]["state_reason"] == "Break confirmed after manual review"
+        assert findings_by_code["rest_period_warning"]["state"] == "dismissed"
+        assert findings_by_code["rest_period_warning"]["state_reason"] == "Previous day checkout corrected"
+        assert review_states == {
+            "break_reminder_after_6h": "resolved",
+            "rest_period_warning": "dismissed",
+        }
+        assert flagged_item["review_state"] == "mixed"
+        assert flagged_item["is_reviewed"] is True
+
+        with pytest.raises(ValueError, match="arbzg_worker_company_scope_denied"):
+            await open_arbzg_finding(
+                session,
+                company_id=company.id,
+                worker_id=other_worker.id,
+                target_date=target_day,
+                finding_code="break_reminder_after_6h",
+                severity="warning",
+                actor_worker_id=owner.id,
+            )
+
+    run_db_test(run_test)
+
+
+def test_arbzg_review_routes_enforce_scope(monkeypatch):
+    async def run_test(session):
+        company = await seed_company(session, "arbzg-route")
+        owner = await seed_worker(
+            session,
+            company.id,
+            "arbzg-route-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        worker = await seed_worker(session, company.id, "arbzg-route-worker")
+        other_company = await seed_company(session, "arbzg-route-other")
+        other_owner = await seed_worker(
+            session,
+            other_company.id,
+            "arbzg-route-other-owner",
+            can_view_dashboard=True,
+            access_role=WorkerAccessRole.COMPANY_OWNER.value,
+            time_tracking_enabled=False,
+        )
+        plain_worker = await seed_worker(
+            session,
+            company.id,
+            "arbzg-route-plain-worker",
+            access_role=WorkerAccessRole.WORKER.value,
+        )
+        await session.commit()
+
+        owner_token = "arbzg-route-owner-token"
+        other_owner_token = "arbzg-route-other-owner-token"
+        worker_token = "arbzg-route-worker-token"
+        monkeypatch.setattr(compliance_router, "decrypt_string", lambda value: value)
+        monkeypatch.setattr(
+            compliance_router,
+            "redis_client",
+            FakeRedis(
+                {
+                    dashboard_token_key(owner_token): build_dashboard_token_payload(
+                        worker_id=owner.id,
+                        company_id=owner.company_id,
+                    ),
+                    dashboard_token_key(other_owner_token): build_dashboard_token_payload(
+                        worker_id=other_owner.id,
+                        company_id=other_owner.company_id,
+                    ),
+                    dashboard_token_key(worker_token): build_dashboard_token_payload(
+                        worker_id=plain_worker.id,
+                        company_id=plain_worker.company_id,
+                    ),
+                }
+            ),
+        )
+
+        opened = await compliance_router.compliance_open_arbzg_review_finding(
+            payload=compliance_router.ArbzgFindingOpenRequest(
+                worker_id=worker.id,
+                target_date=date(2026, 4, 21),
+                finding_code="daily_duration_warning",
+                severity="warning",
+            ),
+            token=owner_token,
+            company_id=None,
+            db=session,
+        )
+        assert opened["state"] == "open"
+
+        updated = await compliance_router.compliance_update_arbzg_review_finding(
+            finding_id=opened["id"],
+            payload=compliance_router.ArbzgFindingStateUpdateRequest(state="reviewed"),
+            token=owner_token,
+            company_id=None,
+            db=session,
+        )
+        findings = await compliance_router.compliance_arbzg_findings(
+            token=owner_token,
+            company_id=None,
+            target_day=date(2026, 4, 21),
+            state=None,
+            db=session,
+        )
+
+        assert updated["state"] == "reviewed"
+        assert findings["items"][0]["finding_code"] == "daily_duration_warning"
+
+        with pytest.raises(HTTPException) as worker_exc:
+            await compliance_router.compliance_open_arbzg_review_finding(
+                payload=compliance_router.ArbzgFindingOpenRequest(
+                    worker_id=worker.id,
+                    target_date=date(2026, 4, 21),
+                    finding_code="daily_duration_warning",
+                ),
+                token=worker_token,
+                company_id=None,
+                db=session,
+            )
+        assert worker_exc.value.status_code == 403
+
+        with pytest.raises(HTTPException) as cross_company_exc:
+            await compliance_router.compliance_arbzg_findings(
+                token=other_owner_token,
+                company_id=company.id,
+                target_day=date(2026, 4, 21),
+                state=None,
+                db=session,
+            )
+        assert cross_company_exc.value.status_code == 403
 
     run_db_test(run_test)
 


### PR DESCRIPTION
## Summary

- implemented phase-2 post-merge refinement on top of the merged Germany hardening baseline
- added explicit GPS requirement resolution for legal onboarding/completion logic
- extended retention from foundation to real non-critical executors for Redis-backed artifacts
- added a lightweight ArbZG review lifecycle without turning it into a large workflow system
- kept retention-hold handling canonical-first while preserving legacy compatibility
- cleaned the remaining Pydantic config warnings
- preserved the canonical BauClock model and did not expand scope into payroll, HR, or large DATEV work

## Schema changes

Added migration:
- `b7f2c1e4d5a6_add_phase2_gps_and_arbzg_findings.py`

New columns:
- `companies.gps_site_presence_required`
- `sites.gps_site_presence_required`
- `workers.gps_site_presence_required_override`

New table:
- `arbzg_findings`

Alembic head:
- `b7f2c1e4d5a6`

## GPS / legal onboarding changes

- introduced explicit GPS requirement resolution instead of coarse/global assumptions
- requirement precedence now supports:
  - worker-level override
  - site-level setting
  - company-level setting
  - safe fallback
- legal onboarding completion now requires GPS notice only when truly required
- compliance-facing completion logic now reflects worker-specific requirement state

## Retention changes

- extended retention executors for non-critical classes
- improved dry-run/destructive reporting behavior
- preserved hold-safe deletion rules
- retained canonical-first handling for retention holds
- reduced ambiguity in hold handling while keeping legacy compatibility for older rows

## ArbZG changes

- added lightweight persistent ArbZG finding lifecycle:
  - `open`
  - `reviewed`
  - `resolved`
  - `dismissed`
- kept ArbZG logic as compliance support, not legal adjudication
- extended reporting/compliance surface accordingly

## Config / framework cleanup

- cleaned Pydantic config warnings in:
  - `api.config`
  - `bot.config`

## Tests

- `.\.venv\Scripts\python.exe -m pytest tests/test_legal_hardening.py -q`
- result: `22 passed`

- `.\.venv\Scripts\python.exe -m pytest`
- result: `164 passed`

## Scope guardrails preserved

This PR does **not**:
- rewrite the architecture
- build a payroll engine
- expand DATEV into a large module
- introduce an absence/HR suite
- broaden UI redesign

Canonical rules preserved:
- `company -> site -> worker/person -> time events -> summaries -> payments/export`
- `CONTRACT` vs `OVERTIME` separation
- `evidence != summary != correction != audit`
- tenant isolation
- bot contour separation

## Known limitations

- exact requested Knowledge-base markdown files were not present in the workspace; implementation aligned with repo-local hardening docs and local mirror context
- `transient_states` retention remains intentionally global-only
- `owner_inv_*` artifacts without company linkage remain excluded from company-scoped retention counts
- legacy `reason` / `expires_at` retention-hold fields remain for backward compatibility
- unrelated untracked local paths were intentionally left outside this PR scope:
  - `api/static/public-ui/`
  - `bauclock-context/`
  - `frontend/`
  - `package-lock.json`
  - `scripts/`

## Review focus

Please review especially:
1. GPS requirement precedence and onboarding completion behavior
2. retention executor/reporting behavior for non-critical classes
3. ArbZG finding lifecycle minimalism and scope
4. compatibility-safe retention hold normalization
5. absence of unwanted scope expansion
