### PR TITLE
chore(bauclock): add development test baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,17 @@ jobs:
           cache: pip
           cache-dependency-path: |
             requirements.txt
+            api/requirements.txt
+            bot/requirements.txt
             requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -r requirements-dev.txt
+          python -m pip install -r requirements.txt
+          python -m pip install -r bot/requirements.txt
+          python -m pip install -r api/requirements.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    env:
+      ENCRYPTION_KEY: 0000000000000000000000000000000000000000000000000000000000000000
+      HASH_PEPPER: test-hash-pepper
+      DATABASE_URL: sqlite+aiosqlite:///./bauclock-test.db
+      REDIS_URL: redis://localhost:6379/0
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,47 @@ Telegram bot (@SEKbaubot) and backend for construction site time tracking, pause
 
 ## Development
 
-- Start local Postgres & Redis using `docker-compose up -d postgres redis`
-- Navigate to `/api` or `/bot` with your virtual environment activated, install `requirements.txt`.
-- Run alembic migrations (to be added) in `/db`.
+Create a local virtual environment from the repository root:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
+```
+
+Copy the example environment file and fill in local secrets:
+
+```bash
+cp .env.example .env
+python -c "import os; print(os.urandom(32).hex())"  # ENCRYPTION_KEY
+python -c "import os; print(os.urandom(16).hex())"  # HASH_PEPPER
+```
+
+Start local Postgres and Redis:
+
+```bash
+docker-compose up -d postgres redis
+```
+
+Run the test suite:
+
+```bash
+pytest
+```
+
+### Alembic Migrations
+
+Alembic is configured in `db/alembic.ini` and reads the application database URL from the same environment as the app.
+
+Apply migrations from the repository root:
+
+```bash
+alembic -c db/alembic.ini upgrade head
+```
+
+Create a new migration from model changes:
+
+```bash
+alembic -c db/alembic.ini revision --autogenerate -m "describe_change"
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==8.2.2
+aiosqlite==0.20.0


### PR DESCRIPTION
## Summary
- Adds BauClock development/test baseline.
- Documents local setup and Alembic migration command.
- Adds dev test requirements and pytest config.
- Adds GitHub Actions test workflow.

## Safety
- No runtime code changed.
- No Docker/deploy changes.
- No auth, crypto, access-control, DB model, migration, bot, or dashboard logic changed.

## Validation
- git diff --check passed.
- Local pytest was not run before this PR because pytest was not installed in the current shell; this PR adds the missing dev requirement and CI workflow.

## Review
ChatGPT should review before merge.
