### PR TITLE
test(bauclock): add request access-control regressions

### DIFF
--- a/tests/test_dashboard_requests_api.py
+++ b/tests/test_dashboard_requests_api.py
@@ -29,7 +29,16 @@ install_import_stubs()
 
 import api.routers.dashboard as dashboard_router
 from db.dashboard_tokens import build_dashboard_token_payload, dashboard_token_key
-from db.models import Base, BillingType, Company, RequestStatus, Worker, WorkerType
+from db.models import (
+    Base,
+    BillingType,
+    Company,
+    RequestStatus,
+    Site,
+    Worker,
+    WorkerAccessRole,
+    WorkerType,
+)
 from db.request_service import create_request
 
 
@@ -76,20 +85,37 @@ async def seed_worker(
     suffix: str,
     *,
     can_view_dashboard: bool = False,
+    site_id: int | None = None,
+    access_role: WorkerAccessRole | None = None,
 ) -> Worker:
     worker = Worker(
         company_id=company_id,
+        site_id=site_id,
         telegram_id_enc=f"telegram_enc_{suffix}",
         telegram_id_hash=f"telegram_hash_{suffix}",
         full_name_enc=f"Worker {suffix}",
         worker_type=WorkerType.FESTANGESTELLT,
         billing_type=BillingType.HOURLY,
+        access_role=(access_role or WorkerAccessRole.WORKER).value,
         can_view_dashboard=can_view_dashboard,
         is_active=True,
     )
     session.add(worker)
     await session.flush()
     return worker
+
+
+async def seed_site(session, company_id: int, suffix: str) -> Site:
+    site = Site(
+        company_id=company_id,
+        name=f"Site {suffix}",
+        address=f"Address {suffix}",
+        qr_token=f"dashboard-site-token-{suffix}",
+        is_active=True,
+    )
+    session.add(site)
+    await session.flush()
+    return site
 
 
 def dashboard_token_for(worker: Worker) -> tuple[str, FakeRedis]:
@@ -213,5 +239,109 @@ def test_reject_action_updates_status(monkeypatch):
         assert response["status"] == RequestStatus.REJECTED.value
         assert refreshed.status == RequestStatus.REJECTED.value
         assert refreshed.resolved_at is None
+
+    run_db_test(run_test)
+
+
+@pytest.mark.parametrize(
+    ("action_name", "expected_status"),
+    [
+        ("dashboard_request_resolve", RequestStatus.RESOLVED.value),
+        ("dashboard_request_reject", RequestStatus.REJECTED.value),
+    ],
+)
+def test_request_action_denies_cross_company_request_id(
+    monkeypatch,
+    action_name,
+    expected_status,
+):
+    async def run_test(session):
+        company = await seed_company(session, f"{action_name}-company")
+        other_company = await seed_company(session, f"{action_name}-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            f"{action_name}-manager",
+            can_view_dashboard=True,
+        )
+        other_worker = await seed_worker(
+            session,
+            other_company.id,
+            f"{action_name}-other-worker",
+        )
+        request = await create_request(
+            session,
+            creator_worker=other_worker,
+            text="Other company request",
+        )
+
+        token, redis_client = dashboard_token_for(manager)
+        monkeypatch.setattr(dashboard_router, "redis_client", redis_client)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await getattr(dashboard_router, action_name)(
+                request_id=request.id,
+                token=token,
+                db=session,
+            )
+
+        refreshed = await session.get(type(request), request.id)
+        assert exc_info.value.status_code == 403
+        assert refreshed.status != expected_status
+        assert refreshed.status == RequestStatus.OPEN.value
+
+    run_db_test(run_test)
+
+
+@pytest.mark.parametrize(
+    ("action_name", "expected_status"),
+    [
+        ("dashboard_request_resolve", RequestStatus.RESOLVED.value),
+        ("dashboard_request_reject", RequestStatus.REJECTED.value),
+    ],
+)
+def test_request_action_denies_objektmanager_out_of_site_request_id(
+    monkeypatch,
+    action_name,
+    expected_status,
+):
+    async def run_test(session):
+        company = await seed_company(session, f"{action_name}-site-scope")
+        own_site = await seed_site(session, company.id, f"{action_name}-own")
+        other_site = await seed_site(session, company.id, f"{action_name}-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            f"{action_name}-site-manager",
+            can_view_dashboard=True,
+            site_id=own_site.id,
+            access_role=WorkerAccessRole.OBJEKTMANAGER,
+        )
+        other_site_worker = await seed_worker(
+            session,
+            company.id,
+            f"{action_name}-other-site-worker",
+            site_id=other_site.id,
+        )
+        request = await create_request(
+            session,
+            creator_worker=other_site_worker,
+            text="Other site request",
+        )
+
+        token, redis_client = dashboard_token_for(manager)
+        monkeypatch.setattr(dashboard_router, "redis_client", redis_client)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await getattr(dashboard_router, action_name)(
+                request_id=request.id,
+                token=token,
+                db=session,
+            )
+
+        refreshed = await session.get(type(request), request.id)
+        assert exc_info.value.status_code == 403
+        assert refreshed.status != expected_status
+        assert refreshed.status == RequestStatus.OPEN.value
 
     run_db_test(run_test)

--- a/tests/test_request_service.py
+++ b/tests/test_request_service.py
@@ -6,7 +6,16 @@ from tempfile import TemporaryDirectory
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from db.models import Base, BillingType, Company, RequestStatus, Worker, WorkerType
+from db.models import (
+    Base,
+    BillingType,
+    Company,
+    RequestStatus,
+    Site,
+    Worker,
+    WorkerAccessRole,
+    WorkerType,
+)
 from db.request_service import (
     RequestAccessError,
     create_request,
@@ -52,20 +61,37 @@ async def seed_worker(
     suffix: str,
     *,
     can_view_dashboard: bool = False,
+    site_id: int | None = None,
+    access_role: WorkerAccessRole | None = None,
 ) -> Worker:
     worker = Worker(
         company_id=company_id,
+        site_id=site_id,
         telegram_id_enc=f"telegram_enc_{suffix}",
         telegram_id_hash=f"telegram_hash_{suffix}",
         full_name_enc=f"name_enc_{suffix}",
         worker_type=WorkerType.FESTANGESTELLT,
         billing_type=BillingType.HOURLY,
+        access_role=(access_role or WorkerAccessRole.WORKER).value,
         can_view_dashboard=can_view_dashboard,
         is_active=True,
     )
     session.add(worker)
     await session.flush()
     return worker
+
+
+async def seed_site(session, company_id: int, suffix: str) -> Site:
+    site = Site(
+        company_id=company_id,
+        name=f"Site {suffix}",
+        address=f"Address {suffix}",
+        qr_token=f"site-token-{suffix}",
+        is_active=True,
+    )
+    session.add(site)
+    await session.flush()
+    return site
 
 
 def test_create_worker_self_request():
@@ -165,6 +191,53 @@ def test_list_company_requests_for_dashboard_capable_manager():
     run_db_test(run_test)
 
 
+def test_list_company_requests_hides_out_of_site_requests_from_objektmanager():
+    async def run_test(session):
+        company = await seed_company(session, "objektmanager-list")
+        own_site = await seed_site(session, company.id, "own")
+        other_site = await seed_site(session, company.id, "other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            "site-manager",
+            can_view_dashboard=True,
+            site_id=own_site.id,
+            access_role=WorkerAccessRole.OBJEKTMANAGER,
+        )
+        own_site_worker = await seed_worker(
+            session,
+            company.id,
+            "own-site-worker",
+            site_id=own_site.id,
+        )
+        other_site_worker = await seed_worker(
+            session,
+            company.id,
+            "other-site-worker",
+            site_id=other_site.id,
+        )
+
+        visible_request = await create_request(
+            session,
+            creator_worker=own_site_worker,
+            text="Visible",
+        )
+        await create_request(
+            session,
+            creator_worker=other_site_worker,
+            text="Hidden",
+        )
+
+        company_requests = await list_company_requests(
+            session,
+            manager_worker=manager,
+        )
+
+        assert {request.id for request in company_requests} == {visible_request.id}
+
+    run_db_test(run_test)
+
+
 def test_list_company_requests_rejects_non_manager_worker():
     async def run_test(session):
         company = await seed_company(session, "denied")
@@ -201,6 +274,68 @@ def test_resolve_request():
     run_db_test(run_test)
 
 
+def test_resolve_request_denies_cross_company_request_id():
+    async def run_test(session):
+        company = await seed_company(session, "resolve-cross")
+        other_company = await seed_company(session, "resolve-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            "manager",
+            can_view_dashboard=True,
+        )
+        other_worker = await seed_worker(session, other_company.id, "other-worker")
+        request = await create_request(
+            session,
+            creator_worker=other_worker,
+            text="Other company",
+        )
+
+        with pytest.raises(RequestAccessError, match="request_not_found"):
+            await resolve_request(
+                session,
+                request_id=request.id,
+                manager_worker=manager,
+            )
+
+    run_db_test(run_test)
+
+
+def test_resolve_request_denies_objektmanager_out_of_site_request_id():
+    async def run_test(session):
+        company = await seed_company(session, "resolve-site-scope")
+        own_site = await seed_site(session, company.id, "resolve-own")
+        other_site = await seed_site(session, company.id, "resolve-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            "site-manager",
+            can_view_dashboard=True,
+            site_id=own_site.id,
+            access_role=WorkerAccessRole.OBJEKTMANAGER,
+        )
+        other_site_worker = await seed_worker(
+            session,
+            company.id,
+            "other-site-worker",
+            site_id=other_site.id,
+        )
+        request = await create_request(
+            session,
+            creator_worker=other_site_worker,
+            text="Other site",
+        )
+
+        with pytest.raises(RequestAccessError, match="request_scope_denied"):
+            await resolve_request(
+                session,
+                request_id=request.id,
+                manager_worker=manager,
+            )
+
+    run_db_test(run_test)
+
+
 def test_reject_request():
     async def run_test(session):
         company = await seed_company(session, "reject")
@@ -222,5 +357,67 @@ def test_reject_request():
         assert rejected.status == RequestStatus.REJECTED.value
         assert rejected.resolved_at is None
         assert rejected.updated_at is not None
+
+    run_db_test(run_test)
+
+
+def test_reject_request_denies_cross_company_request_id():
+    async def run_test(session):
+        company = await seed_company(session, "reject-cross")
+        other_company = await seed_company(session, "reject-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            "manager",
+            can_view_dashboard=True,
+        )
+        other_worker = await seed_worker(session, other_company.id, "other-worker")
+        request = await create_request(
+            session,
+            creator_worker=other_worker,
+            text="Other company",
+        )
+
+        with pytest.raises(RequestAccessError, match="request_not_found"):
+            await reject_request(
+                session,
+                request_id=request.id,
+                manager_worker=manager,
+            )
+
+    run_db_test(run_test)
+
+
+def test_reject_request_denies_objektmanager_out_of_site_request_id():
+    async def run_test(session):
+        company = await seed_company(session, "reject-site-scope")
+        own_site = await seed_site(session, company.id, "reject-own")
+        other_site = await seed_site(session, company.id, "reject-other")
+        manager = await seed_worker(
+            session,
+            company.id,
+            "site-manager",
+            can_view_dashboard=True,
+            site_id=own_site.id,
+            access_role=WorkerAccessRole.OBJEKTMANAGER,
+        )
+        other_site_worker = await seed_worker(
+            session,
+            company.id,
+            "other-site-worker",
+            site_id=other_site.id,
+        )
+        request = await create_request(
+            session,
+            creator_worker=other_site_worker,
+            text="Other site",
+        )
+
+        with pytest.raises(RequestAccessError, match="request_scope_denied"):
+            await reject_request(
+                session,
+                request_id=request.id,
+                manager_worker=manager,
+            )
 
     run_db_test(run_test)


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #13

## Scope

[agent-task-yellow] BauClock test-only request access-control regressions

## Validation

```text
Using cached tzdata-2026.2-py2.py3-none-any.whl (349 kB)
Installing collected packages: webencodings, pytz, passlib, brotli, zopfli, tzlocal, tzdata, typing-extensions, tinycss2, six, redis, python-dotenv, Pyphen, pydyf, pycparser, propcache, Pillow, multidict, MarkupSafe, magic-filter, idna, h11, greenlet, frozenlist, fonttools, click, certifi, attrs, asyncpg, annotated-types, aiofiles, yarl, uvicorn, sqlalchemy, python-dateutil, pydantic-core, Mako, jinja2, html5lib, cssselect2, cffi, apscheduler, anyio, aiosignal, weasyprint, starlette, pydantic, cryptography, arrow, alembic, aiohttp, pydantic-settings, jinja2-time, fastapi, aiogram

Successfully installed Mako-1.3.12 MarkupSafe-3.0.3 Pillow-12.2.0 Pyphen-0.17.2 aiofiles-23.2.1 aiogram-3.7.0 aiohttp-3.9.5 aiosignal-1.4.0 alembic-1.13.1 annotated-types-0.7.0 anyio-4.13.0 apscheduler-3.10.4 arrow-1.4.0 asyncpg-0.29.0 attrs-26.1.0 brotli-1.2.0 certifi-2026.4.22 cffi-2.0.0 click-8.3.3 cryptography-42.0.5 cssselect2-0.9.0 fastapi-0.110.1 fonttools-4.62.1 frozenlist-1.8.0 greenlet-3.5.0 h11-0.16.0 html5lib-1.1 idna-3.13 jinja2-3.1.3 jinja2-time-0.2.0 magic-filter-1.0.12 multidict-6.7.1 passlib-1.7.4 propcache-0.4.1 pycparser-3.0 pydantic-2.6.4 pydantic-core-2.16.3 pydantic-settings-2.2.1 pydyf-0.12.1 python-dateutil-2.9.0.post0 python-dotenv-1.0.1 pytz-2026.1.post1 redis-5.0.3 six-1.17.0 sqlalchemy-2.0.29 starlette-0.37.2 tinycss2-1.5.1 typing-extensions-4.15.0 tzdata-2026.2 tzlocal-5.3.1 uvicorn-0.29.0 weasyprint-61.0 webencodings-0.5.1 yarl-1.23.0 zopfli-0.4.1
Requirement already satisfied: aiogram==3.7.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 1)) (3.7.0)
Requirement already satisfied: redis==5.0.3 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 2)) (5.0.3)
Requirement already satisfied: sqlalchemy==2.0.29 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 3)) (2.0.29)
Requirement already satisfied: asyncpg==0.29.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 4)) (0.29.0)
Requirement already satisfied: cryptography==42.0.5 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 5)) (42.0.5)
Requirement already satisfied: pydantic==2.6.4 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 6)) (2.6.4)
Requirement already satisfied: pydantic-settings==2.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 7)) (2.2.1)
Requirement already satisfied: python-dotenv==1.0.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r bot/requirements.txt (line 8)) (1.0.1)
Collecting qrcode==7.4.2 (from qrcode[pil]==7.4.2->-r bot/requirements.txt (line 9))
  Using cached qrcode-7.4.2-py3-none-any.whl.metadata (17 kB)
Requirement already satisfied: aiofiles~=23.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r bot/requirements.txt (line 1)) (23.2.1)
Requirement already satisfied: aiohttp~=3.9.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r bot/requirements.txt (line 1)) (3.9.5)
Requirement already satisfied: certifi>=2023.7.22 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r bot/requirements.txt (line 1)) (2026.4.22)
Requirement already satisfied: magic-filter<1.1,>=1.0.12 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r bot/requirements.txt (line 1)) (1.0.12)
Requirement already satisfied: typing-extensions<=5.0,>=4.7.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r bot/requirements.txt (line 1)) (4.15.0)
Requirement already satisfied: annotated-types>=0.4.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from pydantic==2.6.4->-r bot/requirements.txt (line 6)) (0.7.0)
Requirement already satisfied: pydantic-core==2.16.3 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from pydantic==2.6.4->-r bot/requirements.txt (line 6)) (2.16.3)
Requirement already satisfied: greenlet!=0.4.17 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from sqlalchemy==2.0.29->-r bot/requirements.txt (line 3)) (3.5.0)
Requirement already satisfied: cffi>=1.12 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from cryptography==42.0.5->-r bot/requirements.txt (line 5)) (2.0.0)
Collecting pypng (from qrcode==7.4.2->qrcode[pil]==7.4.2->-r bot/requirements.txt (line 9))
  Using cached pypng-0.20220715.0-py3-none-any.whl.metadata (13 kB)
Requirement already satisfied: pillow>=9.1.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from qrcode[pil]==7.4.2->-r bot/requirements.txt (line 9)) (12.2.0)
Requirement already satisfied: aiosignal>=1.1.2 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (1.4.0)
Requirement already satisfied: attrs>=17.3.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (26.1.0)
Requirement already satisfied: frozenlist>=1.1.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (1.8.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (6.7.1)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (1.23.0)
Requirement already satisfied: idna>=2.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from yarl<2.0,>=1.0->aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (3.13)
Requirement already satisfied: propcache>=0.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from yarl<2.0,>=1.0->aiohttp~=3.9.0->aiogram==3.7.0->-r bot/requirements.txt (line 1)) (0.4.1)
Requirement already satisfied: pycparser in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from cffi>=1.12->cryptography==42.0.5->-r bot/requirements.txt (line 5)) (3.0)
Using cached qrcode-7.4.2-py3-none-any.whl (46 kB)
Using cached pypng-0.20220715.0-py3-none-any.whl (58 kB)
Installing collected packages: pypng, qrcode

Successfully installed pypng-0.20220715.0 qrcode-7.4.2
Requirement already satisfied: fastapi==0.110.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 1)) (0.110.1)
Requirement already satisfied: uvicorn==0.29.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 2)) (0.29.0)
Requirement already satisfied: sqlalchemy==2.0.29 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 3)) (2.0.29)
Requirement already satisfied: asyncpg==0.29.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 4)) (0.29.0)
Requirement already satisfied: cryptography==42.0.5 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 5)) (42.0.5)
Requirement already satisfied: pydantic==2.6.4 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 6)) (2.6.4)
Requirement already satisfied: pydantic-settings==2.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 7)) (2.2.1)
Requirement already satisfied: python-dotenv==1.0.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 8)) (1.0.1)
Requirement already satisfied: weasyprint==61.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 9)) (61.0)
Requirement already satisfied: jinja2==3.1.3 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 10)) (3.1.3)
Requirement already satisfied: jinja2-time==0.2.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 11)) (0.2.0)
Requirement already satisfied: apscheduler==3.10.4 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 12)) (3.10.4)
Requirement already satisfied: redis==5.0.3 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 13)) (5.0.3)
Requirement already satisfied: qrcode==7.4.2 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from qrcode[pil]==7.4.2->-r api/requirements.txt (line 14)) (7.4.2)
Requirement already satisfied: aiogram==3.7.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 15)) (3.7.0)
Requirement already satisfied: alembic==1.13.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from -r api/requirements.txt (line 16)) (1.13.1)
Requirement already satisfied: starlette<0.38.0,>=0.37.2 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from fastapi==0.110.1->-r api/requirements.txt (line 1)) (0.37.2)
Requirement already satisfied: typing-extensions>=4.8.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from fastapi==0.110.1->-r api/requirements.txt (line 1)) (4.15.0)
Requirement already satisfied: annotated-types>=0.4.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from pydantic==2.6.4->-r api/requirements.txt (line 6)) (0.7.0)
Requirement already satisfied: pydantic-core==2.16.3 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from pydantic==2.6.4->-r api/requirements.txt (line 6)) (2.16.3)
Requirement already satisfied: click>=7.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from uvicorn==0.29.0->-r api/requirements.txt (line 2)) (8.3.3)
Requirement already satisfied: h11>=0.8 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from uvicorn==0.29.0->-r api/requirements.txt (line 2)) (0.16.0)
Requirement already satisfied: greenlet!=0.4.17 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from sqlalchemy==2.0.29->-r api/requirements.txt (line 3)) (3.5.0)
Requirement already satisfied: cffi>=1.12 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from cryptography==42.0.5->-r api/requirements.txt (line 5)) (2.0.0)
Requirement already satisfied: pydyf>=0.8.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (0.12.1)
Requirement already satisfied: html5lib>=1.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (1.1)
Requirement already satisfied: tinycss2>=1.0.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (1.5.1)
Requirement already satisfied: cssselect2>=0.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (0.9.0)
Requirement already satisfied: Pyphen>=0.9.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (0.17.2)
Requirement already satisfied: Pillow>=9.1.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from weasyprint==61.0->-r api/requirements.txt (line 9)) (12.2.0)
Requirement already satisfied: fonttools>=4.0.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from fonttools[woff]>=4.0.0->weasyprint==61.0->-r api/requirements.txt (line 9)) (4.62.1)
Requirement already satisfied: MarkupSafe>=2.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from jinja2==3.1.3->-r api/requirements.txt (line 10)) (3.0.3)
Requirement already satisfied: arrow in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from jinja2-time==0.2.0->-r api/requirements.txt (line 11)) (1.4.0)
Requirement already satisfied: six>=1.4.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from apscheduler==3.10.4->-r api/requirements.txt (line 12)) (1.17.0)
Requirement already satisfied: pytz in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from apscheduler==3.10.4->-r api/requirements.txt (line 12)) (2026.1.post1)
Requirement already satisfied: tzlocal!=3.*,>=2.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from apscheduler==3.10.4->-r api/requirements.txt (line 12)) (5.3.1)
Requirement already satisfied: pypng in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from qrcode==7.4.2->qrcode[pil]==7.4.2->-r api/requirements.txt (line 14)) (0.20220715.0)
Requirement already satisfied: aiofiles~=23.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r api/requirements.txt (line 15)) (23.2.1)
Requirement already satisfied: aiohttp~=3.9.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r api/requirements.txt (line 15)) (3.9.5)
Requirement already satisfied: certifi>=2023.7.22 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r api/requirements.txt (line 15)) (2026.4.22)
Requirement already satisfied: magic-filter<1.1,>=1.0.12 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiogram==3.7.0->-r api/requirements.txt (line 15)) (1.0.12)
Requirement already satisfied: Mako in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from alembic==1.13.1->-r api/requirements.txt (line 16)) (1.3.12)
Requirement already satisfied: aiosignal>=1.1.2 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (1.4.0)
Requirement already satisfied: attrs>=17.3.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (26.1.0)
Requirement already satisfied: frozenlist>=1.1.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (1.8.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (6.7.1)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (1.23.0)
Requirement already satisfied: anyio<5,>=3.4.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from starlette<0.38.0,>=0.37.2->fastapi==0.110.1->-r api/requirements.txt (line 1)) (4.13.0)
Requirement already satisfied: idna>=2.8 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from anyio<5,>=3.4.0->starlette<0.38.0,>=0.37.2->fastapi==0.110.1->-r api/requirements.txt (line 1)) (3.13)
Requirement already satisfied: propcache>=0.2.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from yarl<2.0,>=1.0->aiohttp~=3.9.0->aiogram==3.7.0->-r api/requirements.txt (line 15)) (0.4.1)
Requirement already satisfied: pycparser in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from cffi>=1.12->cryptography==42.0.5->-r api/requirements.txt (line 5)) (3.0)
Requirement already satisfied: webencodings in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from cssselect2>=0.1->weasyprint==61.0->-r api/requirements.txt (line 9)) (0.5.1)
Requirement already satisfied: brotli>=1.0.1 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from fonttools[woff]>=4.0.0->weasyprint==61.0->-r api/requirements.txt (line 9)) (1.2.0)
Requirement already satisfied: zopfli>=0.1.4 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from fonttools[woff]>=4.0.0->weasyprint==61.0->-r api/requirements.txt (line 9)) (0.4.1)
Requirement already satisfied: python-dateutil>=2.7.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from arrow->jinja2-time==0.2.0->-r api/requirements.txt (line 11)) (2.9.0.post0)
Requirement already satisfied: tzdata in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from arrow->jinja2-time==0.2.0->-r api/requirements.txt (line 11)) (2026.2)
Collecting pytest==8.2.2 (from -r requirements-dev.txt (line 1))
  Using cached pytest-8.2.2-py3-none-any.whl.metadata (7.6 kB)
Collecting aiosqlite==0.20.0 (from -r requirements-dev.txt (line 2))
  Using cached aiosqlite-0.20.0-py3-none-any.whl.metadata (4.3 kB)
Collecting iniconfig (from pytest==8.2.2->-r requirements-dev.txt (line 1))
  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
Collecting packaging (from pytest==8.2.2->-r requirements-dev.txt (line 1))
  Using cached packaging-26.2-py3-none-any.whl.metadata (3.5 kB)
Collecting pluggy<2.0,>=1.5 (from pytest==8.2.2->-r requirements-dev.txt (line 1))
  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
Requirement already satisfied: typing_extensions>=4.0 in /home/agent/agent-dev/venvs/bauclock-yellow/lib/python3.12/site-packages (from aiosqlite==0.20.0->-r requirements-dev.txt (line 2)) (4.15.0)
Using cached pytest-8.2.2-py3-none-any.whl (339 kB)
Using cached aiosqlite-0.20.0-py3-none-any.whl (15 kB)
Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
Using cached packaging-26.2-py3-none-any.whl (100 kB)
Installing collected packages: pluggy, packaging, iniconfig, aiosqlite, pytest

Successfully installed aiosqlite-0.20.0 iniconfig-2.3.0 packaging-26.2 pluggy-1.6.0 pytest-8.2.2
...................                                                      [100%]
19 passed in 5.54s
........................................................................ [ 41%]
........................................................................ [ 83%]
.............................                                            [100%]
173 passed in 31.89s
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
