### PR TITLE
ci: add manual tests workflow trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:


### PR DESCRIPTION
Implements #44.

## Summary

Adds `workflow_dispatch` to the existing `Tests` GitHub Actions workflow so maintainers can manually run the same pytest validation used for push/PR checks.

## Scope

Changed file:

```text
.github/workflows/tests.yml
```

No runtime/app/bot/API/database code changed.

## Safety

```text
No deploy.
No server SSH.
No production DB.
No .env reads/writes.
No secrets added.
No dependency, env, Python version, or test command changes.
```

## Why

This unblocks #22 baseline validation by allowing GitHub Actions runner to execute `pytest` on demand instead of requiring manual Codex/local runner execution.

Do not merge until reviewed.